### PR TITLE
fix kEstimateQuantiles kernel

### DIFF
--- a/csrc/kernels.hip
+++ b/csrc/kernels.hip
@@ -630,6 +630,8 @@ __global__ void kEstimateQuantiles(T *__restrict__ const A, float *code, const f
       for(int j = threadIdx.x; j < BLOCK_ESTIMATE; j+=blockDim.x)
           temp_storage.smem_qidx[j] = -1;
 
+      __syncthreads();
+
       if(threadIdx.x < 256)
       {
           float q_interval = (1.0f-(2.0f*offset))/255.0f;

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -91,7 +91,6 @@ def setup():
 def teardown():
     pass
 
-@pytest.mark.skipif(HIP_ENVIRONMENT, reason="this test is not supported on ROCm yet")
 @pytest.mark.parametrize(
     "dtype", [torch.float32, torch.float16], ids=["float", "half"]
 )
@@ -111,7 +110,6 @@ def test_estimate_quantiles(dtype):
     diff = torch.abs(code - quantiles)
     assert (diff > 5e-02).sum().item() == 0
 
-@pytest.mark.skipif(HIP_ENVIRONMENT, reason="this test is not supported on ROCm yet")
 def test_quantile_quantization():
     for i in range(100):
         A1 = torch.randn(1024, 1024, device="cuda")
@@ -2207,7 +2205,6 @@ def test_few_bit_quant():
     #assert False
 
 
-@pytest.mark.skipif(HIP_ENVIRONMENT, reason="this test is not supported on ROCm yet")
 def test_kbit_quantile_estimation():
     for i in range(100):
         data = torch.randn(1024, 1024, device='cuda')


### PR DESCRIPTION
This PR adds synchronization point in kEstimateQuantiles kernel, without which there is a race condition and the kernel fails on Instinct gpus. 

The fix enables these tests:
test_estimate_quantiles
test_quantile_quantization
test_kbit_quantile_estimation