### PR TITLE
Remove blocksize 64 for quant/dequant functions

### DIFF
--- a/bitsandbytes/research/autograd/_functions.py
+++ b/bitsandbytes/research/autograd/_functions.py
@@ -8,6 +8,7 @@ import torch
 import bitsandbytes.functional as F
 
 from bitsandbytes.autograd._functions import MatmulLtState, GlobalOutlierPooler
+from bitsandbytes.cextension import HIP_ENVIRONMENT
 
 
 # math.prod not compatible with python < 3.8
@@ -376,7 +377,10 @@ class SwitchBackBnb(torch.autograd.Function):
 def get_block_sizes(input_matrix, weight_matrix):
     input_features = input_matrix.shape[-1]
     output_features = (weight_matrix.shape[0] if weight_matrix.shape[1] == input_features else weight_matrix.shape[1])
-    array = [4096, 2048, 1024, 512, 256, 128, 64, 0]
+    if not HIP_ENVIRONMENT:
+        array = [4096, 2048, 1024, 512, 256, 128, 64, 0]
+    else:
+        array = [4096, 2048, 1024, 512, 256, 128, 0]
     bsz, bsz2 = 1024, 1024
     for i, k in enumerate(array):
         if input_features > array[i + 1]:

--- a/tests/test_autograd.py
+++ b/tests/test_autograd.py
@@ -549,7 +549,6 @@ has_fp16_weights = [True, False]
 values = list(product(dim1, dim2, dim3, dim4, funcs, dtype, req_grad, transpose))
 str_values = list(product(dim1, dim2, dim3, dim4, str_funcs, dtype, req_grad_str, str_transpose))
 names = ["dim1_{}_dim2_{}_dim3_{}_dim4_{}_func_{}_dtype_{}_requires_grad_{}_transpose_{}".format(*vals) for vals in str_values]
-@pytest.mark.skipif(HIP_ENVIRONMENT, reason="this test is not supported on ROCm yet")
 @pytest.mark.parametrize( "dim1, dim2, dim3, dim4, funcs, dtype, req_grad, transpose", values, ids=names)
 def test_matmul_fp8( dim1, dim2, dim3, dim4, funcs, dtype, req_grad, transpose):
     dimA = (dim2, dim3) if not transpose[0] else (dim3, dim2)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -153,11 +153,14 @@ def test_dynamic_quantization():
         assert diff < 0.004
 
 
-
-@pytest.mark.skipif(HIP_ENVIRONMENT, reason="this test is not supported on ROCm yet")
+def get_blocksizes(hip_env=False):
+    if not hip_env:
+        return [4096, 2048, 1024, 512, 256, 128, 64]
+    else:
+        return [4096, 2048, 1024, 512, 256, 128]
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16], ids=["fp32", "fp16", "bf16"])
 @pytest.mark.parametrize("nested", [False, True], ids=["False", "True"])
-@pytest.mark.parametrize("blocksize", [4096, 2048, 1024, 512, 256, 128, 64])
+@pytest.mark.parametrize("blocksize", get_blocksizes(HIP_ENVIRONMENT))
 @pytest.mark.parametrize("signed", [True, False], ids=['signed_True', 'signed_False'])
 def test_dynamic_blockwise_quantization(dtype, nested, blocksize, signed):
     #print('')
@@ -2283,10 +2286,10 @@ def test_fp4_quant(dtype):
     assert relerr.item() < 0.28
 
 
-@pytest.mark.skipif(HIP_ENVIRONMENT, reason="this test is not supported on ROCm yet")
 @pytest.mark.parametrize("quant_type", ['fp4', 'nf4'])
 def test_4bit_compressed_stats(quant_type):
-    for blocksize in [128, 64]:
+    blocksizes = [128, 64] if not HIP_ENVIRONMENT else [128]
+    for blocksize in blocksizes:
         errs1 = []
         errs2 = []
         for i in range(10):


### PR DESCRIPTION
This PR removes 64 blocksize for quantize and dequantize functions, as ROCm warpsize doesn't support that case.

It also skips that case for tests which use quantize/dequantize functions. These are the tests enabled with this PR:

test_autograd.py::test_matmul_fp8
test_functional.py::test_dynamic_blockwise_quantization
test_functional.py::test_4bit_compressed_stats

