### PR TITLE
Added missing set_device calls for nvidia_transform

### DIFF
--- a/bitsandbytes/backends/cuda.py
+++ b/bitsandbytes/backends/cuda.py
@@ -188,7 +188,10 @@ class CUDABackend(Backend):
         if HIP_ENVIRONMENT:
             # transform kernel formats (col32/col_turing/col_ampere) are not applicable to ROCm
             # Use nvidia_transform instead
-            return nvidia_transform(A, to_order, from_order, out, transpose, state, ld)
+            prev_device = pre_call(A.device)
+            out, new_state = nvidia_transform(A, to_order, from_order, out, transpose, state, ld)
+            post_call(prev_device)
+            return out, new_state
 
         prev_device = pre_call(A.device)
         if state is None:


### PR DESCRIPTION
In `HIP_ENVIRONMENT is True` case, there's missing calls of `pre_call` and `post_call` for proper device setting for `nvidia_transform`.