### PR TITLE
Fix WARP_SIZE detection for gfx942 (MI300X)

### DIFF
--- a/csrc/kernels.hip
+++ b/csrc/kernels.hip
@@ -2853,10 +2853,10 @@ template <int THREADS, int ITEMS_PER_THREAD, int TILE_ROWS, int TILE_COLS, int T
 #define DENORM 1.0f/127.0f
 #define MAX_SPARSE_COUNT 32
 #define SMEM_SIZE 8*256
-#if defined(__GFX9__)
-  #define WARP_SIZE 64
+#ifdef __AMDGCN_WAVEFRONT_SIZE
+  #define WARP_SIZE __AMDGCN_WAVEFRONT_SIZE
 #else
-  #define WARP_SIZE 32
+  #define WARP_SIZE 64
 #endif
 template <typename T, int SPMM_ITEMS, int BITS>
 __global__ void kspmm_coo_very_sparse_naive(int *max_count, int *max_idx, int *offset_rowidx, int *rowidx, int *colidx, half *values, T *B, half *out, float * __restrict__ const dequant_stats, int nnz, int rowsA, int rowsB, int colsB)

--- a/csrc/ops.hip
+++ b/csrc/ops.hip
@@ -20,10 +20,10 @@
 
 #define ERR_NOT_IMPLEMENTED 100
 
-#if defined(__GFX9__)
-  #define WARP_SIZE 64
+#ifdef __AMDGCN_WAVEFRONT_SIZE
+  #define WARP_SIZE __AMDGCN_WAVEFRONT_SIZE
 #else
-  #define WARP_SIZE 32
+  #define WARP_SIZE 64
 #endif
 
 using namespace BinSearch;


### PR DESCRIPTION
## Summary
- Replace broken `__GFX9__` guard with `__AMDGCN_WAVEFRONT_SIZE` (compiler-provided) in both `csrc/kernels.hip` and `csrc/ops.hip`
- Default to WARP_SIZE=64 for CDNA when macro is unavailable
- Fixes 4-bit GEMV inference kernel producing ~50% element mismatches on MI300X (gfx942)

## Root Cause
`__GFX9__` is not defined at compile time on recent ROCm builds, causing `WARP_SIZE=32` on 64-wide wavefront gfx942. This affected:
- `ops.hip`: grid launch computed `num_blocks = (m+3)/4` instead of `(m+1)/2`, skipping half the output rows
- `kernels.hip`: `hipcub::WarpReduce` template and lane/stride calculations used wrong warp width

Same root cause as ROCM-21835. Upstream fix in bitsandbytes-foundation/bitsandbytes PR #1877 (merged 2026-02-24) unified CUDA/HIP sources with `BNB_WARP_SIZE` but was never synced to this fork.

## Test plan
- [x] `pytest -vvv ./tests/test_functional.py::test_gemv_eye_4bit` — 6/6 passed (fp16/bf16/fp32 × nf4/fp4)
- [ ] Full `test_functional.py` suite regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)