### PR TITLE
fix: bypass broken hipblasLt int8 GEMM on gfx950

### DIFF
--- a/bitsandbytes/backends/cuda.py
+++ b/bitsandbytes/backends/cuda.py
@@ -3,7 +3,7 @@ from typing import Literal, Optional, Tuple
 
 import torch
 
-from bitsandbytes.cextension import HIP_ENVIRONMENT, lib
+from bitsandbytes.cextension import HIP_ENVIRONMENT, ROCM_GPU_ARCH, lib
 from bitsandbytes.functional import (
     CUBLAS_Context,
     coo_zeros,
@@ -251,6 +251,9 @@ class CUDABackend(Backend):
         Sout: Optional[Tuple[torch.Size, str]] = None,
         dtype=torch.int32,
     ):
+        if HIP_ENVIRONMENT and ROCM_GPU_ARCH == "gfx950":
+            return self._igemmlt_fallback(A, B, SA, SB, out, Sout, dtype)
+
         shapeA = SA[0]
         shapeB = SB[0]
         dimsA = len(shapeA)
@@ -362,6 +365,57 @@ class CUDABackend(Backend):
         torch.cuda.set_device(prev_device)
 
         return out, Sout
+
+    def _igemmlt_fallback(
+        self,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        SA: Tuple[torch.Size, str],
+        SB: Tuple[torch.Size, str],
+        out: Optional[torch.Tensor] = None,
+        Sout: Optional[Tuple[torch.Size, str]] = None,
+        dtype=torch.int32,
+    ):
+        """Fallback int8 GEMM using torch.matmul for GPUs where hipblasLt int8 is broken.
+
+        On HIP, the "col" transform stores data in column-major order.
+        Col-major (m,k) has lda=m, so element (i,j) is at offset j*m + i.
+        Reading this flat buffer as row-major (m,k) via reshape gives a
+        transposed view. We reshape to (k,m) to get the correct row-major
+        interpretation, then transpose to recover the original (m,k) matrix.
+        """
+        shapeA = SA[0]
+        shapeB = SB[0]
+        dimsA = len(shapeA)
+
+        k = shapeA[-1]
+        n = shapeB[0]
+
+        if dimsA == 2:
+            m = shapeA[0]
+            out_shape = (m, n)
+        elif dimsA == 3:
+            m = shapeA[0] * shapeA[1]
+            out_shape = (shapeA[0], shapeA[1], n)
+        else:
+            raise ValueError(f"igemmlt: unsupported input dimensions: {dimsA}")
+
+        A_orig = A.reshape(k, m).t().contiguous()
+        B_orig = B.reshape(k, n).t().contiguous()
+        C = torch.matmul(A_orig.float(), B_orig.float().t()).round()
+
+        if dtype == torch.int8:
+            C = C.to(torch.int8)
+        else:
+            C = C.to(torch.int32)
+
+        C = C.reshape(out_shape)
+
+        # Transform to "col" format to match hipblasLt output convention.
+        # Callers do nvidia_transform(C, "row", state=Sout) to get row-major.
+        from bitsandbytes.functional import nvidia_transform
+        C_col, Sout = nvidia_transform(C, "col", state=(torch.Size(out_shape), "row"))
+        return C_col, Sout
 
     def mm_dequant(
         self,

--- a/bitsandbytes/backends/cuda.py
+++ b/bitsandbytes/backends/cuda.py
@@ -414,6 +414,7 @@ class CUDABackend(Backend):
         # Transform to "col" format to match hipblasLt output convention.
         # Callers do nvidia_transform(C, "row", state=Sout) to get row-major.
         from bitsandbytes.functional import nvidia_transform
+
         C_col, Sout = nvidia_transform(C, "col", state=(torch.Size(out_shape), "row"))
         return C_col, Sout
 

--- a/bitsandbytes/backends/cuda.py
+++ b/bitsandbytes/backends/cuda.py
@@ -376,13 +376,16 @@ class CUDABackend(Backend):
         Sout: Optional[Tuple[torch.Size, str]] = None,
         dtype=torch.int32,
     ):
-        """Fallback int8 GEMM using torch.matmul for GPUs where hipblasLt int8 is broken.
+        """Row-major int8 GEMM via torch._int_mm, bypassing broken hipblasLt col-major path.
 
-        On HIP, the "col" transform stores data in column-major order.
-        Col-major (m,k) has lda=m, so element (i,j) is at offset j*m + i.
-        Reading this flat buffer as row-major (m,k) via reshape gives a
-        transposed view. We reshape to (k,m) to get the correct row-major
-        interpretation, then transpose to recover the original (m,k) matrix.
+        hipblasLt's column-major Int8 GEMM kernel has a tiling bug on gfx950:
+        works for <=64 columns, wrong results for >=128, and OOB writes on
+        large inputs causing unrecoverable GPU faults.
+
+        This recovers the original row-major matrices from the col-major
+        transformed inputs (reshape k,m then transpose), computes via
+        torch._int_mm (row-major, no hipblasLt), then transforms the
+        output back to col format for callers.
         """
         shapeA = SA[0]
         shapeB = SB[0]
@@ -400,23 +403,29 @@ class CUDABackend(Backend):
         else:
             raise ValueError(f"igemmlt: unsupported input dimensions: {dimsA}")
 
-        A_orig = A.reshape(k, m).t().contiguous()
-        B_orig = B.reshape(k, n).t().contiguous()
-        C = torch.matmul(A_orig.float(), B_orig.float().t()).round()
+        A_row = A.reshape(k, m).t().contiguous()
+        B_row = B.reshape(k, n).t().contiguous()
+
+        # torch._int_mm requires K (inner dim) and N (B^T columns) to be multiples of 8
+        pad_k = (8 - k % 8) % 8
+        pad_n = (8 - n % 8) % 8
+        if pad_k:
+            A_row = torch.nn.functional.pad(A_row, (0, pad_k))
+            B_row = torch.nn.functional.pad(B_row, (0, pad_k))
+        if pad_n:
+            B_row = torch.nn.functional.pad(B_row, (0, 0, 0, pad_n))
+
+        C = torch._int_mm(A_row, B_row.t())
+
+        if pad_n:
+            C = C[:, :n]
 
         if dtype == torch.int8:
             C = C.to(torch.int8)
-        else:
-            C = C.to(torch.int32)
 
         C = C.reshape(out_shape)
-
-        # Transform to "col" format to match hipblasLt output convention.
-        # Callers do nvidia_transform(C, "row", state=Sout) to get row-major.
-        from bitsandbytes.functional import nvidia_transform
-
-        C_col, Sout = nvidia_transform(C, "col", state=(torch.Size(out_shape), "row"))
-        return C_col, Sout
+        Sout = (torch.Size(out_shape), "row")
+        return C, Sout
 
     def mm_dequant(
         self,

--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -517,6 +517,10 @@ def nvidia_transform(
         state = (A.shape, from_order)
     else:
         from_order = state[1]
+
+    if from_order == to_order:
+        return A.clone(), (state[0], to_order)
+
     if out is None:
         out, new_state = get_transform_buffer(state[0], A.dtype, A.device, to_order, state[1], transpose)
     else:


### PR DESCRIPTION
## Root cause

hipBLASLt's column-major Int8 GEMM kernel has a tiling bug on gfx950 — works for ≤64 columns, produces wrong results for ≥128 columns, and writes out of bounds on large inputs causing unrecoverable GPU page faults. The col-major int32 matrix transform is also broken.

## Fix

Bypass the broken hipBLASLt col-major path on gfx950 by routing Int8 GEMM through `torch._int_mm` (row-major), which works correctly at all sizes. Python-only patch, no rebuild needed.

**Changes:**
- `bitsandbytes/backends/cuda.py`: Add `_igemmlt_fallback()` gated on `ROCM_GPU_ARCH == "gfx950"`. Recovers row-major matrices from col-major transformed inputs, computes via `torch._int_mm` with K/N padding to multiples of 8, returns result in row format
- `bitsandbytes/functional.py`: Add no-op short-circuit in `nvidia_transform()` when `from_order == to_order` (needed because fallback returns row-format output)

## Test plan
- [x] `pytest -xvs tests/test_functional.py -k "igemmlt and cuda"` — 2/2 passed (dims=2 and dims=3)
- [x] `pytest -xvs tests/test_functional.py -k "igemmlt"` — 3 passed, 12 skipped, 0 failed
- [x] Manual verification: 6 shapes (2D + 3D, including non-multiple-of-8 K and N) with max_diff=0.0