### PR TITLE
Fix flaky Lion optimizer test on HIP/AMD GPUs

### DIFF
--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -160,9 +160,11 @@ def test_optimizer32bit(dim1, dim2, gtype, optim_name):
                 rtol=rtol,
             )
 
-        # since Lion can have pretty noisy updates where things lie at the boundary
-        # allow up to 10 errors for Lion
-        assert_most_approx_close(p1, p2.float(), atol=atol, rtol=rtol, max_error_count=10)
+        # Lion uses sgn() which amplifies FMA rounding differences at the
+        # sign boundary; HIP/clang contracts FMA differently from nvcc,
+        # producing more boundary flips on AMD GPUs.
+        lion_max_err = max(10, p1.numel() // 200000)
+        assert_most_approx_close(p1, p2.float(), atol=atol, rtol=rtol, max_error_count=lion_max_err)
 
         if i % (k // 5) == 0 and i > 0:
             path = get_temp_dir()
@@ -172,18 +174,14 @@ def test_optimizer32bit(dim1, dim2, gtype, optim_name):
             bnb_optimizer = str2optimizers[optim_name][1]([p2])
             bnb_optimizer.load_state_dict(torch.load(join(path, "opt.pt")))
             rm_path(path)
-            # since Lion can have pretty noisy updates where things lie at the boundary
-            # allow up to 10 errors for Lion
-            assert_most_approx_close(p1, p2.float(), atol=atol, rtol=rtol, max_error_count=10)
+            assert_most_approx_close(p1, p2.float(), atol=atol, rtol=rtol, max_error_count=lion_max_err)
             for name1, name2 in str2statenames[optim_name]:
-                # since Lion can have pretty noisy updates where things lie at the boundary
-                # allow up to 10 errors for Lion
                 assert_most_approx_close(
                     torch_optimizer.state[p1][name1],
                     bnb_optimizer.state[p2][name2],
                     atol=atol,
                     rtol=rtol,
-                    max_error_count=10,
+                    max_error_count=lion_max_err,
                 )
 
         if gtype != torch.float32:


### PR DESCRIPTION
## Summary
- Scale `max_error_count` in `test_optimizer32bit` with tensor size instead of hardcoding 10
- Fixes flaky `test_optimizer32bit[dim2=4097-dim1=1024-fp32-opt=lion]` on MI300X (~30% failure rate)

## Root Cause
Lion uses `sgn()` on a lerp of momentum and gradient. When the lerp value is near zero, the fused bnb kernel and the separate-op PyTorch reference can disagree on the sign due to different FMA contraction by HIP's clang vs nvcc. Each sign flip causes exactly `2 * lr = 0.0002` error. Larger tensors have more boundary cases — the 4.19M element case was hitting ~12 errors against a limit of 10.

New formula: `max(10, p1.numel() // 200000)` — keeps the floor at 10 for small tensors, scales up for larger ones.

## Test plan
- [x] Flaky test `dim2=4097-dim1=1024-fp32-opt=lion`: 10/10 passes (was 7/10 before)
- [x] Full `test_optim.py`: 151 passed, 26 skipped, 0 failed
- [x] Full `test_functional.py`: 411 passed, 339 skipped, 0 failures related to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)